### PR TITLE
#16090 Update caching behaviour

### DIFF
--- a/src/main/java/io/kontur/insightsapi/controller/TileController.java
+++ b/src/main/java/io/kontur/insightsapi/controller/TileController.java
@@ -58,8 +58,11 @@ public class TileController {
         Instant lastUpdated = indicatorService.getIndicatorsLastUpdateDate();
         if (lastUpdated == null) {
             return ResponseEntity.ok()
-                    .body(new byte[0]);
+                    .cacheControl(CacheControl.empty().cachePublic())
+                    .header("Expires", HTTP_TIME_FORMATTER.format(Instant.now()))
+                    .body(tileService.getBivariateTileMvt(z, x, y, indicatorsClass));
         }
+
         Instant expirationTime = lastUpdated.plus(Duration.ofDays(1));
         String eTag = lastUpdated.toString();
 
@@ -102,8 +105,11 @@ public class TileController {
         Instant lastUpdated = indicatorService.getIndicatorsLastUpdateDate();
         if (lastUpdated == null) {
             return ResponseEntity.ok()
-                    .body(new byte[0]);
+                    .cacheControl(CacheControl.empty().cachePublic())
+                    .header("Expires", HTTP_TIME_FORMATTER.format(Instant.now()))
+                    .body(tileService.getBivariateTileMvtIndicatorsList(z, x, y, indicatorsList));
         }
+
         Instant expirationTime = lastUpdated.plus(Duration.ofDays(1));
         String eTag = lastUpdated.toString();
 


### PR DESCRIPTION
- Do not return empty tiles when bivariate_indicstors_wrk table is empty or last_updated field is not set