### PR TITLE
fix task_queue migration: check if unique constraint exists

### DIFF
--- a/src/main/resources/db/changelog/add-task-queue-table.sql
+++ b/src/main/resources/db/changelog/add-task-queue-table.sql
@@ -12,6 +12,16 @@ create table if not exists task_queue
     created_at       timestamptz default now()::timestamptz
 );
 
-alter table task_queue
-    add constraint task_queue_unique unique nulls not distinct (
-        task_type, x_numerator_id, x_denominator_id, y_numerator_id, y_denominator_id);
+do $$
+begin
+    if not exists (select
+                   from information_schema.constraint_table_usage
+                   where table_name='task_queue' and constraint_name='task_queue_unique') then
+        alter table task_queue
+            add constraint task_queue_unique unique nulls not distinct (
+                task_type, x_numerator_id, x_denominator_id, y_numerator_id, y_denominator_id);
+    else
+        raise notice 'skip task_queue_unique creation: already exists';
+    end if;
+end;
+$$


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Змяненні**
	- Мадыфікаваная функцыянальнасць для ўмовнага дадання унікальнага абмежавання на табліцу `task_queue` ў залежнасці ад яе існавання, з праверкай на адсутнасць дадатковага дадатковага абмежавання, калі яно ўжо існуе.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->