### PR TITLE
fix task_queue migration for pg14

### DIFF
--- a/src/main/resources/db/changelog/add-task-queue-table.sql
+++ b/src/main/resources/db/changelog/add-task-queue-table.sql
@@ -17,9 +17,19 @@ begin
     if not exists (select
                    from information_schema.constraint_table_usage
                    where table_name='task_queue' and constraint_name='task_queue_unique') then
-        alter table task_queue
-            add constraint task_queue_unique unique nulls not distinct (
-                task_type, x_numerator_id, x_denominator_id, y_numerator_id, y_denominator_id);
+        if (select version() ~ 'PostgreSQL 16') then
+            -- 'nulls not distinct' is syntax error for pg14, so wrapping it in `execute`
+            execute 'alter table task_queue
+                add constraint task_queue_unique unique nulls not distinct (
+                    task_type, x_numerator_id, x_denominator_id, y_numerator_id, y_denominator_id)';
+        else
+            create unique index task_queue_1_unique on task_queue (task_type, x_numerator_id)
+                where x_denominator_id is null and y_numerator_id is null and y_denominator_id is null;
+            create unique index task_queue_2_unique on task_queue (task_type, x_numerator_id, x_denominator_id)
+                where x_denominator_id is not null and y_numerator_id is null and y_denominator_id is null;
+            create unique index task_queue_4_unique on task_queue (task_type, x_numerator_id, x_denominator_id, y_numerator_id, y_denominator_id)
+                where x_denominator_id is not null and y_numerator_id is not null and y_denominator_id is not null;
+        end if;
     else
         raise notice 'skip task_queue_unique creation: already exists';
     end if;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новыя магчымасці**
	- Мадыфікаваная логіка для дадання ўнікальнага абмежавання да табліцы `task_queue` для адаптацыі да сінтаксічных адрозненняў на аснове версій PostgreSQL. У PostgreSQL 16, абмежаванне дадаецца напрамую, у той час як для ранейшых версій ствараюцца ўнікальныя індэксы на аснове розных камбінацый сталбцаў.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->