### PR TITLE
fix public filter for tiles on old schema

### DIFF
--- a/src/main/java/io/kontur/insightsapi/repository/TileRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/TileRepository.java
@@ -85,7 +85,7 @@ public class TileRepository {
         String bivariateIndicatorsTable = useStatSeparateTables ? bivariateIndicatorsMetadataTableName
                 : bivariateIndicatorsTableName;
         var query = String.format("select param_id from %s", bivariateIndicatorsTable);
-        if (publicOnly) {
+        if (publicOnly && useStatSeparateTables) {
             query += " where is_public";
         }
         return jdbcTemplate.query(query, (rs, rowNum) -> rs.getString("param_id"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Новыя магчымасці**
	- Мадыфікаваныя ўмовы запыту для біварыятных індыкатараў у залежнасці ад значэнняў `publicOnly` і `useStatSeparateTables`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->