### PR TITLE
MVT: return null instead of 0 if no indicator data in polygon

### DIFF
--- a/src/main/java/io/kontur/insightsapi/repository/TileRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/TileRepository.java
@@ -101,7 +101,7 @@ public class TileRepository {
 
             for (BivariateIndicatorDto indicator : bivariateIndicatorDtos) {
                 outerFilter.add(String.format("'%s'", indicator.getInternalId()));
-                columns.add(String.format("coalesce(avg(indicator_value) filter (where indicator_uuid = '%s'), 0) as \"%s\"",
+                columns.add(String.format("avg(indicator_value) filter (where indicator_uuid = '%s') as \"%s\"",
                         indicator.getInternalId(), indicator.getId()));
             }
 
@@ -111,7 +111,7 @@ public class TileRepository {
 
         } else {
             return String.format(queryFactory.getSql(getTileMvtResource),
-                    StringUtils.join(bivariateIndicators.stream().map(current -> String.format("coalesce(%s, 0) as %s",
+                    StringUtils.join(bivariateIndicators.stream().map(current -> String.format("%s as %s",
                             current, current)).toList(), ", "));
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified SQL query generation logic in `TileRepository.java` to remove the `coalesce` function for certain indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->