### PR TITLE
use mean_all_res and stddev_all_res for /axis api

### DIFF
--- a/src/main/resources/sql.queries/axis_info.sql
+++ b/src/main/resources/sql.queries/axis_info.sql
@@ -28,9 +28,8 @@ select
                        'quality', quality,
                        'datasetStats', jsonb_build_object('minValue', min,
                                                           'maxValue', max,
-                                                          -- TODO: replace mean_value and stddev_value with metrics calculated by all resolutions, not only 8
-                                                          'mean', mean_value,
-                                                          'stddev', stddev_value),
+                                                          'mean', mean_all_res,
+                                                          'stddev', stddev_all_res),
                        'steps', jsonb_build_array(
                                jsonb_build_object('value', min, 'label', min_label),
                                jsonb_build_object('value', p25, 'label', p25_label),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced statistical metrics reporting by aggregating data across all available resolutions for improved accuracy and comprehensiveness.
- **Bug Fixes**
	- Corrected the calculation method for statistical metrics to ensure more reliable data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->