### PR TITLE
set floor() and ceil() for steps in APIs

### DIFF
--- a/src/main/java/io/kontur/insightsapi/model/DatasetStats.java
+++ b/src/main/java/io/kontur/insightsapi/model/DatasetStats.java
@@ -17,12 +17,12 @@ public class DatasetStats implements Serializable {
     @Serial
     private static final long serialVersionUID = 1722430120010101010L;
 
-    private Double minValue;
+    private Double minValue;  // min value of all resolution hexes
 
-    private Double maxValue;
+    private Double maxValue;  // max value of all resolution hexes
 
-    private Double mean;
+    private Double mean;  // mean value of all resolution hexes
 
-    private Double stddev;
+    private Double stddev;  // stddev value of all resolution hexes
 
 }

--- a/src/main/resources/sql.queries/axis_info.sql
+++ b/src/main/resources/sql.queries/axis_info.sql
@@ -26,15 +26,17 @@ select
                                                                              'longName', bul2.long_name))
                            ),
                        'quality', quality,
+                        -- used by FE for MCDA value range:
                        'datasetStats', jsonb_build_object('minValue', min,
                                                           'maxValue', max,
                                                           'mean', mean_all_res,
                                                           'stddev', stddev_all_res),
+                        -- used by FE for bivariate layers boundaries:
                        'steps', jsonb_build_array(
-                               jsonb_build_object('value', min, 'label', min_label),
+                               jsonb_build_object('value', floor(min), 'label', min_label),
                                jsonb_build_object('value', p25, 'label', p25_label),
                                jsonb_build_object('value', p75, 'label', p75_label),
-                               jsonb_build_object('value', max, 'label', max_label))) as axis
+                               jsonb_build_object('value', ceil(max), 'label', max_label))) as axis
 from
     bivariate_axis_v2 ba,
     bivariate_indicators_metadata bi1 left join bivariate_unit_localization bul1 on bi1.unit_id = bul1.unit_id,

--- a/src/main/resources/sql.queries/axis_statistic.sql
+++ b/src/main/resources/sql.queries/axis_statistic.sql
@@ -27,10 +27,10 @@ select
                            ),
                        'quality', quality,
                        'steps', jsonb_build_array(
-                               jsonb_build_object('value', min, 'label', min_label),
+                               jsonb_build_object('value', floor(min), 'label', min_label),
                                jsonb_build_object('value', p25, 'label', p25_label),
                                jsonb_build_object('value', p75, 'label', p75_label),
-                               jsonb_build_object('value', max, 'label', max_label))) as axis
+                               jsonb_build_object('value', ceil(max), 'label', max_label))) as axis
 from
     %s,
     %s bi1 left join bivariate_unit_localization bul1 on bi1.unit_id = bul1.unit_id,

--- a/src/main/resources/sql.queries/bivariate_statistic.sql
+++ b/src/main/resources/sql.queries/bivariate_statistic.sql
@@ -54,10 +54,10 @@ select
                                                                                    ),
                                                                   'steps',
                                                                   jsonb_build_array(
-                                                                      jsonb_build_object('value', x.min, 'label', x.min_label),
+                                                                      jsonb_build_object('value', floor(x.min), 'label', x.min_label),
                                                                       jsonb_build_object('value', x.p25, 'label', x.p25_label),
                                                                       jsonb_build_object('value', x.p75, 'label', x.p75_label),
-                                                                      jsonb_build_object('value', x.max, 'label', x.max_label))),
+                                                                      jsonb_build_object('value', ceil(x.max), 'label', x.max_label))),
                                           'y', jsonb_build_object('label', y.label, 'quotient',
                                                                   jsonb_build_array(y.numerator, y.denominator),
                                                                   'quotients',
@@ -87,10 +87,10 @@ select
                                                                                    ),
                                                                   'steps',
                                                                   jsonb_build_array(
-                                                                      jsonb_build_object('value', y.min, 'label', y.min_label),
+                                                                      jsonb_build_object('value', floor(y.min), 'label', y.min_label),
                                                                       jsonb_build_object('value', y.p25, 'label', y.p25_label),
                                                                       jsonb_build_object('value', y.p75, 'label', y.p75_label),
-                                                                      jsonb_build_object('value', y.max, 'label', y.max_label)))
+                                                                      jsonb_build_object('value', ceil(y.max), 'label', y.max_label)))
                            ),
                        'overlays', ov.overlay
         )::text
@@ -100,10 +100,10 @@ from
               jsonb_build_object('label', label, 'quotient', jsonb_build_array(numerator, denominator), 'quality',
                                  quality,
                                  'steps', jsonb_build_array(
-                                     jsonb_build_object('value', min, 'label', min_label),
+                                     jsonb_build_object('value', floor(min), 'label', min_label),
                                      jsonb_build_object('value', p25, 'label', p25_label),
                                      jsonb_build_object('value', p75, 'label', p75_label),
-                                     jsonb_build_object('value', max, 'label', max_label)))) as axis
+                                     jsonb_build_object('value', ceil(max), 'label', max_label)))) as axis
       from
           %s )                                                                      ba,
     ( select
@@ -138,10 +138,10 @@ from
                                                                                ),
                                                               'steps',
                                                               jsonb_build_array(
-                                                                      jsonb_build_object('value', ax.min, 'label', ax.min_label),
+                                                                      jsonb_build_object('value', floor(ax.min), 'label', ax.min_label),
                                                                       jsonb_build_object('value', ax.p25, 'label', ax.p25_label),
                                                                       jsonb_build_object('value', ax.p75, 'label', ax.p75_label),
-                                                                      jsonb_build_object('value', ax.max, 'label', ax.max_label))),
+                                                                      jsonb_build_object('value', ceil(ax.max), 'label', ax.max_label))),
                                       'y', jsonb_build_object('label', ay.label,
                                                               'quotient', jsonb_build_array(ay.numerator, ay.denominator),
                                                               'quotients',
@@ -171,10 +171,10 @@ from
                                                                                ),
                                                               'steps',
                                                               jsonb_build_array(
-                                                                      jsonb_build_object('value', ay.min, 'label', ay.min_label),
+                                                                      jsonb_build_object('value', floor(ay.min), 'label', ay.min_label),
                                                                       jsonb_build_object('value', ay.p25, 'label', ay.p25_label),
                                                                       jsonb_build_object('value', ay.p75, 'label', ay.p75_label),
-                                                                      jsonb_build_object('value', ay.max, 'label', ay.max_label))))
+                                                                      jsonb_build_object('value', ceil(ay.max), 'label', ay.max_label))))
                    order by ord) as overlay
       from
           %s     ax,

--- a/src/main/resources/sql.queries/bivariate_statistic_v2.sql
+++ b/src/main/resources/sql.queries/bivariate_statistic_v2.sql
@@ -56,10 +56,10 @@ select
                                                                   'transformation', x.default_transform,
                                                                   'steps',
                                                                   jsonb_build_array(
-                                                                      jsonb_build_object('value', x.min, 'label', x.min_label),
+                                                                      jsonb_build_object('value', floor(x.min), 'label', x.min_label),
                                                                       jsonb_build_object('value', x.p25, 'label', x.p25_label),
                                                                       jsonb_build_object('value', x.p75, 'label', x.p75_label),
-                                                                      jsonb_build_object('value', x.max, 'label', x.max_label))),
+                                                                      jsonb_build_object('value', ceil(x.max), 'label', x.max_label))),
                                           'y', jsonb_build_object('label', y.label, 'quotient',
                                                                   jsonb_build_array(y.numerator, y.denominator),
                                                                   'quotients',
@@ -90,10 +90,10 @@ select
                                                                   'transformation', y.default_transform,
                                                                   'steps',
                                                                   jsonb_build_array(
-                                                                      jsonb_build_object('value', y.min, 'label', y.min_label),
+                                                                      jsonb_build_object('value', floor(y.min), 'label', y.min_label),
                                                                       jsonb_build_object('value', y.p25, 'label', y.p25_label),
                                                                       jsonb_build_object('value', y.p75, 'label', y.p75_label),
-                                                                      jsonb_build_object('value', y.max, 'label', y.max_label)))
+                                                                      jsonb_build_object('value', ceil(y.max), 'label', y.max_label)))
                            ),
                        'overlays', ov.overlay
         )::text
@@ -104,10 +104,10 @@ from
                                  quality,
                                  'transformation', default_transform,
                                  'steps', jsonb_build_array(
-                                     jsonb_build_object('value', min, 'label', min_label),
+                                     jsonb_build_object('value', floor(min), 'label', min_label),
                                      jsonb_build_object('value', p25, 'label', p25_label),
                                      jsonb_build_object('value', p75, 'label', p75_label),
-                                     jsonb_build_object('value', max, 'label', max_label)))) as axis
+                                     jsonb_build_object('value', ceil(max), 'label', max_label)))) as axis
       from
           bivariate_axis_v2 b,
           bivariate_indicators_metadata m1,
@@ -151,10 +151,10 @@ from
                                                               'transformation', ax.default_transform,
                                                               'steps',
                                                               jsonb_build_array(
-                                                                      jsonb_build_object('value', ax.min, 'label', ax.min_label),
+                                                                      jsonb_build_object('value', floor(ax.min), 'label', ax.min_label),
                                                                       jsonb_build_object('value', ax.p25, 'label', ax.p25_label),
                                                                       jsonb_build_object('value', ax.p75, 'label', ax.p75_label),
-                                                                      jsonb_build_object('value', ax.max, 'label', ax.max_label))),
+                                                                      jsonb_build_object('value', ceil(ax.max), 'label', ax.max_label))),
                                       'y', jsonb_build_object('label', ay.label,
                                                               'quotient', jsonb_build_array(ay.numerator, ay.denominator),
                                                               'quotients',
@@ -185,10 +185,10 @@ from
                                                               'transformation', ay.default_transform,
                                                               'steps',
                                                               jsonb_build_array(
-                                                                      jsonb_build_object('value', ay.min, 'label', ay.min_label),
+                                                                      jsonb_build_object('value', floor(ay.min), 'label', ay.min_label),
                                                                       jsonb_build_object('value', ay.p25, 'label', ay.p25_label),
                                                                       jsonb_build_object('value', ay.p75, 'label', ay.p75_label),
-                                                                      jsonb_build_object('value', ay.max, 'label', ay.max_label))))
+                                                                      jsonb_build_object('value', ceil(ay.max), 'label', ay.max_label))))
                    order by ord) as overlay
       from
           bivariate_axis_v2     ax,

--- a/src/main/resources/sql.queries/statistic_all.sql
+++ b/src/main/resources/sql.queries/statistic_all.sql
@@ -47,18 +47,18 @@ select
                                                                   jsonb_build_array(x.numerator, x.denominator),
                                                                   'steps',
                                                                   jsonb_build_array(
-                                                                      jsonb_build_object('value', x.min, 'label', x.min_label),
+                                                                      jsonb_build_object('value', floor(x.min), 'label', x.min_label),
                                                                       jsonb_build_object('value', x.p25, 'label', x.p25_label),
                                                                       jsonb_build_object('value', x.p75, 'label', x.p75_label),
-                                                                      jsonb_build_object('value', x.max, 'label', x.max_label))),
+                                                                      jsonb_build_object('value', ceil(x.max), 'label', x.max_label))),
                                           'y', jsonb_build_object('label', y.label, 'quotient',
                                                                   jsonb_build_array(y.numerator, y.denominator),
                                                                   'steps',
                                                                   jsonb_build_array(
-                                                                      jsonb_build_object('value', y.min, 'label', y.min_label),
+                                                                      jsonb_build_object('value', floor(y.min), 'label', y.min_label),
                                                                       jsonb_build_object('value', y.p25, 'label', y.p25_label),
                                                                       jsonb_build_object('value', y.p75, 'label', y.p75_label),
-                                                                      jsonb_build_object('value', y.max, 'label', y.max_label)))
+                                                                      jsonb_build_object('value', ceil(y.max), 'label', y.max_label)))
                            ),
                        'overlays', ov.overlay
         )::text
@@ -68,10 +68,10 @@ from
               jsonb_build_object('label', label, 'quotient', jsonb_build_array(numerator, denominator), 'quality',
                                  quality,
                                  'steps', jsonb_build_array(
-                                     jsonb_build_object('value', min, 'label', min_label),
+                                     jsonb_build_object('value', floor(min), 'label', min_label),
                                      jsonb_build_object('value', p25, 'label', p25_label),
                                      jsonb_build_object('value', p75, 'label', p75_label),
-                                     jsonb_build_object('value', max, 'label', max_label)))) as axis
+                                     jsonb_build_object('value', ceil(max), 'label', max_label)))) as axis
       from
           %s )                                                                      ba,
     ( select
@@ -85,10 +85,10 @@ from
                                                                       jsonb_build_object('name', bix2.param_id, 'label', bix2.param_label, 'direction', bix2.direction)),
                                                               'steps',
                                                               jsonb_build_array(
-                                                                  jsonb_build_object('value', ax.min, 'label', ax.min_label),
+                                                                  jsonb_build_object('value', floor(ax.min), 'label', ax.min_label),
                                                                   jsonb_build_object('value', ax.p25, 'label', ax.p25_label),
                                                                   jsonb_build_object('value', ax.p75, 'label', ax.p75_label),
-                                                                  jsonb_build_object('value', ax.max, 'label', ax.max_label))),
+                                                                  jsonb_build_object('value', ceil(ax.max), 'label', ax.max_label))),
                                       'y', jsonb_build_object('label', ay.label,
                                                               'quotient', jsonb_build_array(ay.numerator, ay.denominator),
                                                               'quotients',
@@ -97,10 +97,10 @@ from
                                                                       jsonb_build_object('name', biy2.param_id, 'label', biy2.param_label, 'direction', biy2.direction)),
                                                               'steps',
                                                               jsonb_build_array(
-                                                                  jsonb_build_object('value', ay.min, 'label', ay.min_label),
+                                                                  jsonb_build_object('value', floor(ay.min), 'label', ay.min_label),
                                                                   jsonb_build_object('value', ay.p25, 'label', ay.p25_label),
                                                                   jsonb_build_object('value', ay.p75, 'label', ay.p75_label),
-                                                                  jsonb_build_object('value', ay.max, 'label', ay.max_label))))
+                                                                  jsonb_build_object('value', ceil(ay.max), 'label', ay.max_label))))
                    order by ord) as overlay
       from
           %s     ax,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced statistical output in JSON format by adding fields for `minValue`, `maxValue`, `mean`, and `stddev`.
	- Improved calculation methods for `min` and `max` values using rounding functions for better precision in JSON outputs.

- **Bug Fixes**
	- Adjusted calculations for minimum and maximum values in various SQL queries to ensure accurate representation in outputs.

- **Documentation**
	- Added comments to clarify the purpose of fields in the `DatasetStats` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->