### PR TITLE
indicator upload: copy CSV to temp table instead of stat_h3_transposed

### DIFF
--- a/src/main/java/io/kontur/insightsapi/dto/IndicatorState.java
+++ b/src/main/java/io/kontur/insightsapi/dto/IndicatorState.java
@@ -4,5 +4,6 @@ public enum IndicatorState {
     NEW,
     READY,
     OUTDATED,
+    TMP_CREATED,
     COPY_IN_PROGRESS
 }

--- a/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
+++ b/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
@@ -128,8 +128,7 @@ public class IndicatorService {
         String[] parts = result.split("/");
         String externalId = parts[0];
         String indicatorState = parts[1];
-        System.out.println(indicatorState); 
-        if (indicatorState.equals("COPY IN PROGRESS")) {
+        if (indicatorState.equals("COPY IN PROGRESS") || indicatorState.equals("TMP CREATED")) {
             return ResponseEntity.status(HttpStatus.ACCEPTED).body(indicatorState);
         } else if (indicatorState == null) {
             // indicator not found by upload_id


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/693192b2-f300-438e-92a8-500085e9d456)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a new temporary state `TMP_CREATED` for indicator uploads.
	- Enhanced upload process state management.

- **Bug Fixes**
	- Improved error handling for concurrent indicator uploads.
	- Updated status checking mechanism for upload processes.

- **Refactor**
	- Modified indicator upload state tracking logic.
	- Updated method signatures to support new temporary table handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->