### PR TITLE
indicator upload endpoint: add downscale param

### DIFF
--- a/src/main/java/io/kontur/insightsapi/controller/IndicatorController.java
+++ b/src/main/java/io/kontur/insightsapi/controller/IndicatorController.java
@@ -53,7 +53,7 @@ public class IndicatorController {
                     "${layer_ispublic}, \\\"copyrights\\\": ${layer_copyrights}, \\\"description\\\": " +
                     "${layer_description}, \\\"coverage\\\": ${layer_coverage}, \\\"updateFrequency\\\": " +
                     "${layer_update_freq}, \\\"unitId\\\": ${layer_unit_id}, \\\"emoji\\\": ${emoji}, " +
-                    "\\\"lastUpdated\\\": ${layer_last_updated}}\" " +
+                    "\\\"lastUpdated\\\": ${layer_last_updated}, \\\"downscale\\\": ${downscaleMethod}}\" " +
                     "--form 'file=@\"/path/to/file/indicator.csv\"'" +
 
                     "<br><br>Curl example with parameters: curl -w \":::\"%{http_code} --location --request POST " +
@@ -62,7 +62,7 @@ public class IndicatorController {
                     "\"Area\", \"direction\": [[\"neutral\"], [\"neutral\"]], \"isBase\": true, \"isPublic\": false, " +
                     "\"copyrights\": [\"Concept of areas © Brahmagupta, René Descartes\"], \"description\": \"\", " +
                     "\"coverage\": \"World\", \"updateFrequency\": \"static\", \"unitId\": \"km2\", \"emoji\": \"📐\", "+
-                    "\"lastUpdated\": \"\"}' " +
+                    "\"lastUpdated\": \"\", \"downscale\": \"equal\"}' " +
                     "--form 'file=@\"data/area_km2.csv\"'",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful upload"),
@@ -92,7 +92,7 @@ public class IndicatorController {
                     "${layer_ispublic}, \\\"copyrights\\\": ${layer_copyrights}, \\\"description\\\": " +
                     "${layer_description}, \\\"coverage\\\": ${layer_coverage}, \\\"updateFrequency\\\": " +
                     "${layer_update_freq}, \\\"unitId\\\": ${layer_unit_id}, \\\"emoji\\\": ${emoji}, " +
-                    "\\\"lastUpdated\\\": ${layer_last_updated}}\" " +
+                    "\\\"lastUpdated\\\": ${layer_last_updated}, \\\"downscale\\\": ${downscaleMethod}}\" " +
                     "--form 'file=@\"/path/to/file/indicator.csv\"'" +
 
                     "<br><br>Curl example with parameters: curl -w \":::\"%{http_code} --location --request PUT " +
@@ -101,7 +101,7 @@ public class IndicatorController {
                     "\"Area\", \"uuid\": \"7efd9ba2-e7de-44b9-8140-26c89e8170d7\", \"direction\": [[\"neutral\"], [\"neutral\"]], \"isBase\": true, \"isPublic\": false, " +
                     "\"copyrights\": [\"Concept of areas © Brahmagupta, René Descartes\"], \"description\": \"\", " +
                     "\"coverage\": \"World\", \"updateFrequency\": \"static\", \"unitId\": \"km2\", \"emoji\": \"📐\", "+
-                    "\"lastUpdated\": \"\"}' " +
+                    "\"lastUpdated\": \"\", \"downscale\": \"equal\"}' " +
                     "--form 'file=@\"data/area_km2.csv\"'",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful upload"),

--- a/src/main/java/io/kontur/insightsapi/dto/BivariateIndicatorDto.java
+++ b/src/main/java/io/kontur/insightsapi/dto/BivariateIndicatorDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -78,6 +79,10 @@ public class BivariateIndicatorDto {
 
     @JsonProperty(value = "lastUpdated")
     private OffsetDateTime lastUpdated;
+
+    @JsonProperty(value = "downscale")
+    @Pattern(regexp = "equal|proportional", message = "Scale must be 'equal' or 'proportional'")
+    private String downscale;
 
     @JsonIgnore
     private String uploadId;

--- a/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
@@ -303,5 +303,6 @@ public class IndicatorRepository {
         ps.setString(15, bivariateIndicatorDto.getEmoji());
         ps.setString(16, bivariateIndicatorDto.getLastUpdated() == null ? null : bivariateIndicatorDto.getLastUpdated().toString());
         ps.setString(17, bivariateIndicatorDto.getUploadId());
+        ps.setString(18, bivariateIndicatorDto.getDownscale());
     }
 }

--- a/src/main/resources/sql.queries/insert_bivariate_indicators.sql
+++ b/src/main/resources/sql.queries/insert_bivariate_indicators.sql
@@ -1,5 +1,5 @@
 INSERT INTO %s (param_id, param_label, copyrights, direction, is_base, internal_id,
                 external_id, owner, state, is_public, allowed_users, date, description,
-                coverage, update_frequency, application, unit_id, emoji, last_updated, upload_id)
-VALUES (?, ?, ?::json, ?::json, ?, gen_random_uuid(), ?::uuid, ?, 'COPY IN PROGRESS', ?, ?::json, now(), ?, ?, ?, ?::json, ?, ?, ?::timestamptz, ?::uuid)
+                coverage, update_frequency, application, unit_id, emoji, last_updated, upload_id, downscale)
+VALUES (?, ?, ?::json, ?::json, ?, gen_random_uuid(), ?::uuid, ?, 'COPY IN PROGRESS', ?, ?::json, now(), ?, ?, ?, ?::json, ?, ?, ?::timestamptz, ?::uuid, ?)
 RETURNING internal_id::text;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `downscale` parameter for bivariate indicators
  - Introduced validation for downscale values (must be "equal" or "proportional")

- **Documentation**
  - Updated API documentation to reflect new parameter requirements for indicator uploads

- **Technical Improvements**
  - Enhanced data structure to support additional scaling type information
  - Modified database insertion process to include new downscale column

<!-- end of auto-generated comment: release notes by coderabbit.ai -->