### PR TITLE
shut-down-indicator-upload-endpoint

### DIFF
--- a/src/main/java/io/kontur/insightsapi/controller/IndicatorController.java
+++ b/src/main/java/io/kontur/insightsapi/controller/IndicatorController.java
@@ -70,7 +70,9 @@ public class IndicatorController {
                     @ApiResponse(responseCode = "500", description = "Internal error")})
     @PostMapping(value = "/upload", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<String> createIndicator(HttpServletRequest request) {
-        return indicatorService.uploadIndicatorData(request, false);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+            .body("Service is temporarily unavailable due to maintenance");
+        //return indicatorService.uploadIndicatorData(request, false);
     }
 
     @Operation(
@@ -110,7 +112,9 @@ public class IndicatorController {
                     @ApiResponse(responseCode = "500", description = "Internal error")})
     @PutMapping(value = "/upload", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<String> updateIndicator(HttpServletRequest request) {
-        return indicatorService.uploadIndicatorData(request, true);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+            .body("Service is temporarily unavailable due to maintenance");
+        //return indicatorService.uploadIndicatorData(request, true);
     }
 
     @Operation(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
	- Temporarily disabled indicator creation and update services
	- Service now returns a maintenance unavailability message when attempting to create or update indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->