### PR TITLE
analytics/urbanCore: substitute indicator id in java

### DIFF
--- a/src/main/java/io/kontur/insightsapi/repository/PopulationRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/PopulationRepository.java
@@ -188,8 +188,11 @@ public class PopulationRepository {
         var paramSource = new MapSqlParameterSource("polygon", geojson);
         var transformedGeometry = helper.transformGeometryToWkt(geojson);
         paramSource.addValue("transformed_polygon", transformedGeometry);
+        Map<String, String> indicators = indicatorRepository.getSelectedBivariateIndicators(Arrays.asList("population"))
+            .stream().collect(Collectors.toMap(BivariateIndicatorDto::getId, BivariateIndicatorDto::getInternalId));
         try {
-            return namedParameterJdbcTemplate.queryForObject(queryFactory.getSql(populationUrbanCoreV2), paramSource, (rs, rowNum) ->
+            return namedParameterJdbcTemplate.queryForObject(
+                    String.format(queryFactory.getSql(populationUrbanCoreV2), indicators.get("population")), paramSource, (rs, rowNum) ->
                     UrbanCore.builder()
                             .urbanCorePopulation(rs.getBigDecimal("urbanCorePopulation"))
                             .urbanCoreAreaKm2(rs.getBigDecimal("urbanCoreAreaKm2"))

--- a/src/main/resources/sql.queries/population_urbancore_v2.sql
+++ b/src/main/resources/sql.queries/population_urbancore_v2.sql
@@ -11,7 +11,7 @@ with resolution as (select calculate_area_resolution_v2(ST_SetSRID(:polygon::geo
      res as (select st.h3, st.indicator_value as population, h3_cell_area(st.h3, 'km^2') as area_km2
              from stat_h3_transposed st
              join hexes using(h3)
-             where indicator_uuid = (select internal_id from bivariate_indicators_metadata where param_id = 'population' and state = 'READY')),
+             where indicator_uuid = '%s'),
      stat_pop as (select s.*, sum(population) over (order by population desc) as sum_pop
                   from res s),
      total as (select sum(population)                  as population,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for calculating urban core population data by dynamically integrating relevant population indicators.
- **Chores**
	- Streamlined the underlying SQL query structure for population metrics, simplifying parameter substitution for more consistent data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->