### PR TITLE
return coverage_polygon in indicators/{id} API

### DIFF
--- a/src/main/java/io/kontur/insightsapi/dto/BivariateIndicatorDto.java
+++ b/src/main/java/io/kontur/insightsapi/dto/BivariateIndicatorDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.wololo.geojson.GeoJSON;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -86,6 +87,9 @@ public class BivariateIndicatorDto {
 
     @JsonProperty(value = "hash")
     private String hash;
+
+    @JsonProperty(value = "coveragePolygon")
+    private GeoJSON coveragePolygon;
 
     @JsonIgnore
     private String uploadId;

--- a/src/main/java/io/kontur/insightsapi/mapper/BivariateIndicatorRowMapper.java
+++ b/src/main/java/io/kontur/insightsapi/mapper/BivariateIndicatorRowMapper.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Service;
+import org.wololo.geojson.GeoJSONFactory;
 
 import java.sql.ResultSet;
 import java.time.OffsetDateTime;
@@ -60,6 +61,12 @@ public class BivariateIndicatorRowMapper implements RowMapper<BivariateIndicator
         bivariateIndicatorDto.setEmoji(resultSet.getString(BivariateIndicatorsColumns.emoji.name()));
         bivariateIndicatorDto.setDownscale(resultSet.getString(BivariateIndicatorsColumns.downscale.name()));
         bivariateIndicatorDto.setHash(resultSet.getString(BivariateIndicatorsColumns.hash.name()));
+        String coveragePolygon = resultSet.getString(BivariateIndicatorsColumns.coverage_polygon.name());
+        if (coveragePolygon != null) {
+            bivariateIndicatorDto.setCoveragePolygon(GeoJSONFactory.create(coveragePolygon));
+        } else {
+            bivariateIndicatorDto.setCoveragePolygon(null);
+        }
         bivariateIndicatorDto.setLastUpdated(resultSet.getObject(BivariateIndicatorsColumns.last_updated.name(),
                 OffsetDateTime.class));
         return bivariateIndicatorDto;
@@ -68,6 +75,6 @@ public class BivariateIndicatorRowMapper implements RowMapper<BivariateIndicator
     private enum BivariateIndicatorsColumns {
         param_id, param_label, copyrights, direction, is_base, external_id, internal_id, owner, state, is_public,
         allowed_users, date, description, coverage, update_frequency, application, unit_id, emoji, last_updated,
-        downscale, hash
+        downscale, hash, coverage_polygon 
     }
 }

--- a/src/main/resources/db/changelog/add_column_coverage_polygon.sql
+++ b/src/main/resources/db/changelog/add_column_coverage_polygon.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+--changeset insights-api:add_column_coverage_polygon splitStatements:false stripComments:false endDelimiter:; runOnChange:true
+
+alter table bivariate_indicators_metadata
+add column if not exists coverage_polygon geometry;

--- a/src/main/resources/db/changelog/master-changelog.xml
+++ b/src/main/resources/db/changelog/master-changelog.xml
@@ -12,4 +12,5 @@
     <include  file="add_table_bivariate_unit.sql" relativeToChangelogFile="true"/>
     <include  file="add_table_bivariate_unit_localization.sql" relativeToChangelogFile="true"/>
     <include  file="add_table_bivariate_colors.sql" relativeToChangelogFile="true"/>
+    <include  file="add_column_coverage_polygon.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/sql.queries/advanced_analytics_intersect_all_indicators.sql
+++ b/src/main/resources/sql.queries/advanced_analytics_intersect_all_indicators.sql
@@ -6,7 +6,7 @@ with validated_input as (select ST_MakeValid(ST_SimplifyVW((:polygon)::geometry,
              from boxinput bi
                       cross join subdivision sb
                       join stat_h3_geom sh on (sh.geom && bi.bbox and st_intersects(sh.geom, sb.geom) and sh.resolution <= :max_resolution)),
-     ids as materialized (select internal_id from bivariate_indicators_metadata where state = 'READY' and is_public),
+     ids as materialized (select distinct on (param_id) internal_id from bivariate_indicators_metadata where state = 'READY' and is_public order by param_id, date desc),
      res as (select st.h3, st.indicator_uuid, st.indicator_value
              from stat_h3_transposed st
              join hexes h on (h.h3 = st.h3)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a coverage polygon field to bivariate indicators, enabling GeoJSON coverage areas to be included in indicator data.

- **Bug Fixes**
  - Improved indicator selection in analytics queries to ensure only the latest indicator per parameter is used.

- **Chores**
  - Updated database schema to include a new coverage polygon column for bivariate indicators.
  - Adjusted database queries and repository methods to accommodate new and updated fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->