### PR TITLE
sort UUIDs when reading indicators from stat_h3_transposed

### DIFF
--- a/src/main/java/io/kontur/insightsapi/repository/DatabaseUtil.java
+++ b/src/main/java/io/kontur/insightsapi/repository/DatabaseUtil.java
@@ -52,6 +52,8 @@ public class DatabaseUtil {
         for (BivariateIndicatorDto indicator : indicators) {
             uuids.add("'" + indicator.getInternalId() + "'");
         }
+        // for better SQL performance, sort uuids:
+        uuids.sort(String::compareTo);
         return uuids;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency by ensuring UUID lists are now always returned in sorted order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->