### PR TITLE
Add REST endpoint stubs in Python

### DIFF
--- a/docs/migration_to_python.md
+++ b/docs/migration_to_python.md
@@ -4,34 +4,39 @@ This document outlines a phased approach for rewriting the Insights API from Jav
 
 ## Step-by-step Plan
 
-1. **Generate project skeleton**
+1. **Generate project skeleton** ✅
    - Create a new Python package in a `python/` directory with a minimal Starlette application.
    - Provide a `README_PYTHON.md` describing environment setup and how to run the server.
 
-2. **Recreate REST endpoints**
+2. **Recreate REST endpoints** ✅
    - Implement routes with Starlette to mirror existing Java endpoints.
    - Use asynchronous request handlers.
 
 3. **Port business logic**
    - Translate service classes and utilities to Python modules.
-   - Use `aiohttp` for any external HTTP calls.
+   - Use Pydantic models for request and response validation.
+   - Utilize `aiohttp` for any external HTTP calls.
 
 4. **Replace data access layer**
-   - Replace Java persistence logic with `asyncpg` for asynchronous PostgreSQL queries.
-   - Migrate repository logic and SQL scripts.
+   - Implement repository classes using `asyncpg` for asynchronous PostgreSQL queries.
+   - Provide database migrations and port existing SQL scripts.
 
 5. **Introduce testing framework**
    - Set up pytest and `pytest-asyncio` for unit and integration tests.
    - Reimplement existing Java tests in Python.
+   - Integrate coverage reporting and run tests in CI.
 
 6. **Incremental migration**
    - Gradually replace Java components with Python modules while keeping both stacks operational.
    - Maintain interoperability via HTTP APIs during the transition.
+   - Provide fallbacks to Java endpoints when functionality is missing in Python.
 
 7. **Update CI/CD pipeline**
    - Configure Python tooling and dependency management.
+   - Build and publish a Docker image for the Python service.
    - Ensure new code passes linting and tests in CI.
 
 ## Status
 
 A Python skeleton exists under `python/` with a basic Starlette application.
+REST and GraphQL endpoint stubs are now available in `insights_api.__init__`.

--- a/python/insights_api/__init__.py
+++ b/python/insights_api/__init__.py
@@ -1,10 +1,126 @@
 from starlette.applications import Starlette
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
-async def homepage(request):
-    return JSONResponse({'message': 'Hello from Python API'})
 
-app = Starlette(debug=True, routes=[
-    Route('/', homepage)
-])
+async def homepage(request):
+    return JSONResponse({"message": "Hello from Python API"})
+
+
+async def clean_caches(request):
+    """Placeholder implementation of cache eviction endpoint."""
+    return JSONResponse({"status": "caches evicted"})
+
+
+async def get_bivariate_tile_v1(request):
+    """Return empty vector tile placeholder."""
+    return Response(b"", media_type="application/vnd.mapbox-vector-tile")
+
+
+async def calculate_population(request):
+    """Calculate population statistic (stub)."""
+    await request.body()
+    return JSONResponse({"statistic": "todo"})
+
+
+async def focus_humanitarian_impact(request):
+    """Return humanitarian impact result (stub)."""
+    await request.body()
+    return JSONResponse({"impact": "todo"})
+
+
+async def calculate_population_several(request):
+    """Calculate population for several polygons (stub)."""
+    await request.body()
+    return JSONResponse([])
+
+
+async def get_bivariate_tile_v2(request):
+    """Return empty vector tile placeholder for API v2."""
+    return Response(b"", media_type="application/vnd.mapbox-vector-tile")
+
+
+async def graphql_endpoint(request):
+    """Placeholder for GraphQL queries."""
+    await request.body()
+    return JSONResponse({"data": None})
+
+
+async def upload_indicator(request):
+    """Stub for indicator upload."""
+    await request.body()
+    return JSONResponse({"uploadId": "todo"})
+
+
+async def update_indicator(request):
+    """Stub for indicator update."""
+    await request.body()
+    return JSONResponse({"uploadId": "todo"})
+
+
+async def upload_status(request):
+    """Return upload status (stub)."""
+    upload_id = request.path_params["upload_id"]
+    return JSONResponse({"uploadId": upload_id, "status": "processing"})
+
+
+async def list_indicators(request):
+    """Return list of indicators (stub)."""
+    return JSONResponse([])
+
+
+async def get_indicator(request):
+    """Return indicator metadata (stub)."""
+    indicator_id = request.path_params["id"]
+    return JSONResponse({"id": indicator_id})
+
+
+async def upload_axis_overrides(request):
+    """Stub for uploading custom axis labels."""
+    await request.body()
+    return JSONResponse({"status": "received"})
+
+
+app = Starlette(
+    debug=True,
+    routes=[
+        Route("/", homepage),
+        Route("/cache/cleanUp", clean_caches, methods=["GET"]),
+        Route(
+            "/tiles/bivariate/v1/{z:int}/{x:int}/{y:int}.mvt",
+            get_bivariate_tile_v1,
+            methods=["GET"],
+        ),
+        Route(
+            "/tiles/bivariate/v2/{z:int}/{x:int}/{y:int}.mvt",
+            get_bivariate_tile_v2,
+            methods=["GET"],
+        ),
+        Route("/population", calculate_population, methods=["POST"]),
+        Route(
+            "/population/humanitarian_impact",
+            focus_humanitarian_impact,
+            methods=["POST"],
+        ),
+        Route(
+            "/population/several",
+            calculate_population_several,
+            methods=["POST"],
+        ),
+        Route("/indicators/upload", upload_indicator, methods=["POST"]),
+        Route("/indicators/upload", update_indicator, methods=["PUT"]),
+        Route(
+            "/indicators/upload/status/{upload_id}",
+            upload_status,
+            methods=["GET"],
+        ),
+        Route("/indicators", list_indicators, methods=["GET"]),
+        Route("/indicators/{id}", get_indicator, methods=["GET"]),
+        Route(
+            "/indicators/axis/custom",
+            upload_axis_overrides,
+            methods=["POST"],
+        ),
+        Route("/graphql", graphql_endpoint, methods=["POST"]),
+    ],
+)


### PR DESCRIPTION
## Summary
- implement Starlette routes mirroring Java controllers, including GraphQL and upload endpoints
- mark first two migration steps as done and expand next steps
- include GraphQL stub in migration status

## Testing
- `python -m py_compile python/insights_api/*.py`
