### PR TITLE
graphql functions: exclude nulls from avg

### DIFF
--- a/src/main/java/io/kontur/insightsapi/repository/FunctionsRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/FunctionsRepository.java
@@ -105,7 +105,7 @@ public class FunctionsRepository implements FunctionsService {
                     validX + ") filter (where " + validX + " != 0 and " + validX + " is not null)) * 100 as result" + validId;
             case "maxX" -> "max(" + validX + ") as result" + validId;
             case "minX" -> "min(" + validX + ") as result" + validId;
-            case "avgX" -> "avg(" + validX + ") as result" + validId;
+            case "avgX" -> "(avg(" + validX + ") filter (where " + validX + " != 0 and " + validX + " is not null)) as result" + validId;
             case "countX" -> "count(" + validX + ") as result" + validId;
             default -> null;
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of average calculations by excluding zero and null values from the results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->