### PR TITLE
Update indicator upload to reuse existing uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ environment and python script with test. More about test framework here http://d
 5) Some **TODOs** added among the code
 6) Java version is 16 for Insights
 7) All method names reflect their behavior
+8) `POST /indicators/upload` reuses the existing indicator UUID if metadata with the same `param_id` already exists for the current owner

--- a/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
@@ -294,6 +294,16 @@ public class IndicatorRepository {
         }
     }
 
+    public String getExternalIdByOwnerAndParamId(String owner, String paramId) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT external_id FROM bivariate_indicators_metadata WHERE owner = ? AND param_id = ? order by date desc limit 1",
+                    String.class, owner, paramId);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
     // TODO: possibly will be added something about owner field here
     @Transactional(readOnly = true)
     public List<BivariateIndicatorDto> getAllBivariateIndicators() {

--- a/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
+++ b/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
@@ -65,14 +65,20 @@ public class IndicatorService {
 
                     indicatorMetadata.setOwner(authService.getCurrentUsername().orElseThrow());
 
-                    if (isUpdate) {
-                        if (invalidIndicatorExternalId(indicatorMetadata.getExternalId())) {
-                            return logAndReturnErrorWithMessage(HttpStatus.NOT_FOUND,
-                                    "Indicator with uuid " + indicatorMetadata.getExternalId() + " not found");
-                        }
+                if (isUpdate) {
+                    if (invalidIndicatorExternalId(indicatorMetadata.getExternalId())) {
+                        return logAndReturnErrorWithMessage(HttpStatus.NOT_FOUND,
+                                "Indicator with uuid " + indicatorMetadata.getExternalId() + " not found");
+                    }
+                } else {
+                    String existingExternalId = indicatorRepository.getExternalIdByOwnerAndParamId(
+                            indicatorMetadata.getOwner(), indicatorMetadata.getId());
+                    if (existingExternalId != null) {
+                        indicatorMetadata.setExternalId(existingExternalId);
                     } else {
                         indicatorMetadata.setExternalId(randomUUID().toString());
                     }
+                }
                     itemIndex++;
                 } else if (!item.isFormField() && "file".equals(item.getFieldName()) && itemIndex == 1) {
                     indicatorRepository.checkActiveUpload(indicatorMetadata);


### PR DESCRIPTION
## Summary
- reuse indicator external_id when POSTing a new indicator with an existing param_id
- expose repository helper to fetch external_id by owner and param_id
- document new POST behaviour

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d825f45c48324b96ea05c18195d20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify that uploading indicators will now reuse an existing indicator UUID if metadata with the same parameter ID already exists for the current owner.

- **Bug Fixes**
  - Improved indicator upload logic to reuse the existing indicator UUID when applicable, preventing unnecessary creation of duplicate identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->