### PR TITLE
Add smart POST indicator upload

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -7,7 +7,7 @@ This document summarizes the available HTTP and GraphQL endpoints implemented in
 | Method | Path | Description | Source |
 |-------|------|-------------|-------|
 | GET | `/cache/cleanUp` | Clean all caches | `CacheController` |
-| POST | `/indicators/upload` | Create indicator by uploading CSV data and metadata | `IndicatorController` |
+| POST | `/indicators/upload` | Create indicator by uploading CSV data and metadata. If an indicator with the same `param_id` already exists, a new version is created using its existing uuid. | `IndicatorController` |
 | PUT | `/indicators/upload` | Update indicator data | `IndicatorController` |
 | GET | `/indicators/upload/status/{uploadId}` | Get indicator upload status | `IndicatorController` |
 | GET | `/indicators` | Get indicators metadata for the current user | `IndicatorController` |

--- a/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
@@ -294,6 +294,16 @@ public class IndicatorRepository {
         }
     }
 
+    public String getExternalIdByOwnerAndParamId(String owner, String paramId) {
+        try {
+            return jdbcTemplateRW.queryForObject(
+                    "SELECT external_id FROM bivariate_indicators_metadata WHERE owner = ? AND param_id = ? ORDER BY date DESC LIMIT 1",
+                    String.class, owner, paramId);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
     // TODO: possibly will be added something about owner field here
     @Transactional(readOnly = true)
     public List<BivariateIndicatorDto> getAllBivariateIndicators() {

--- a/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
+++ b/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
@@ -71,7 +71,13 @@ public class IndicatorService {
                                     "Indicator with uuid " + indicatorMetadata.getExternalId() + " not found");
                         }
                     } else {
-                        indicatorMetadata.setExternalId(randomUUID().toString());
+                        String existingId = indicatorRepository.getExternalIdByOwnerAndParamId(
+                                indicatorMetadata.getOwner(), indicatorMetadata.getId());
+                        if (existingId != null) {
+                            indicatorMetadata.setExternalId(existingId);
+                        } else {
+                            indicatorMetadata.setExternalId(randomUUID().toString());
+                        }
                     }
                     itemIndex++;
                 } else if (!item.isFormField() && "file".equals(item.getFieldName()) && itemIndex == 1) {


### PR DESCRIPTION
## Summary
- reuse existing external_id for POST /indicators/upload when indicator with the same param_id already exists
- document updated indicator upload behaviour

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d93e887e08324a17ad0bbabe2072e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the behavior of the POST `/indicators/upload` endpoint regarding handling of existing indicators with the same parameter ID.

- **Bug Fixes**
  - Improved indicator upload logic to reuse an existing identifier when uploading an indicator with the same owner and parameter ID, instead of always generating a new one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->