### PR TITLE
Handle gzip uploads

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -7,8 +7,8 @@ This document summarizes the available HTTP and GraphQL endpoints implemented in
 | Method | Path | Description | Source |
 |-------|------|-------------|-------|
 | GET | `/cache/cleanUp` | Clean all caches | `CacheController` |
-| POST | `/indicators/upload` | Create indicator by uploading CSV data and metadata. If an indicator with the same `param_id` already exists, a new version is created using its existing uuid. | `IndicatorController` |
-| PUT | `/indicators/upload` | Update indicator data | `IndicatorController` |
+| POST | `/indicators/upload` | Create indicator by uploading CSV data and metadata. Requests may be gzip-compressed. If an indicator with the same `param_id` already exists, a new version is created using its existing uuid. | `IndicatorController` |
+| PUT | `/indicators/upload` | Update indicator data. Requests may be gzip-compressed. | `IndicatorController` |
 | GET | `/indicators/upload/status/{uploadId}` | Get indicator upload status | `IndicatorController` |
 | GET | `/indicators` | Get indicators metadata for the current user | `IndicatorController` |
 | GET | `/indicators/{id}` | Get indicators metadata by ID for the current user | `IndicatorController` |

--- a/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
+++ b/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
@@ -11,7 +11,9 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.fileupload.FileItemIterator;
 import org.apache.commons.fileupload.FileItemStream;
 import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.RequestContext;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload.servlet.ServletRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,7 @@ import org.springframework.stereotype.Service;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.*;
 import java.io.*;
+import java.util.zip.GZIPInputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.Path;
@@ -50,10 +53,38 @@ public class IndicatorService {
 
     public static final int UUID_STRING_LENGTH = 36;
 
+    private FileItemIterator getItemIterator(HttpServletRequest request) throws FileUploadException, IOException {
+        if ("gzip".equalsIgnoreCase(request.getHeader("Content-Encoding"))) {
+            RequestContext context = new RequestContext() {
+                @Override
+                public String getCharacterEncoding() {
+                    return request.getCharacterEncoding();
+                }
+
+                @Override
+                public String getContentType() {
+                    return request.getContentType();
+                }
+
+                @Override
+                public int getContentLength() {
+                    return request.getContentLength();
+                }
+
+                @Override
+                public InputStream getInputStream() throws IOException {
+                    return new GZIPInputStream(request.getInputStream());
+                }
+            };
+            return upload.getItemIterator(context);
+        }
+        return upload.getItemIterator(new ServletRequestContext(request));
+    }
+
     public ResponseEntity<String> uploadIndicatorData(HttpServletRequest request, boolean isUpdate) {
         try {
             BivariateIndicatorDto indicatorMetadata = null;
-            FileItemIterator itemIterator = upload.getItemIterator(request);
+            FileItemIterator itemIterator = getItemIterator(request);
             int itemIndex = 0;
 
             while (itemIterator.hasNext()) {


### PR DESCRIPTION
## Summary
- support gzip-compressed multipart requests in upload endpoints
- document gzip support for POST/PUT `/indicators/upload`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6846b3a0cb848324b3a56d93efaedfb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for gzip-compressed uploads when creating or updating indicator data via the relevant API endpoints.

- **Documentation**
  - Updated API documentation to indicate gzip compression support for indicator data upload endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->