### PR TITLE
Improve cache clean up logic

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ This folder contains documentation summarizing key aspects of the Insights API. 
 
 - [Endpoints](endpoints.md) – list of REST and GraphQL endpoints.
 - [Database Schema](database_schema.md) – overview of the schema created via Liquibase.
+- [Caching](caching.md) – how Redis caches are used by the service.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -25,8 +25,15 @@ Feature flags under the `cache` section allow enabling or disabling cache usage 
 
 Only parameters of known DTO types are scanned for indicator IDs when composing
 versioned cache keys. Strings or generic lists are ignored, so callers that need
-per-indicator caching must pass the IDs using `BivariateIndicatorDto`,
-`NumeratorsDenominatorsDto`, `FunctionArgs` or related DTOs.
+per‑indicator caching must pass the IDs using `BivariateIndicatorDto`,
+`NumeratorsDenominatorsDto`, `FunctionArgs` or related DTOs. The resulting key
+ends with a version suffix:
+
+```
+hash_part1_hash_part2_id1:timestamp-id2:timestamp
+```
+
+If no indicator IDs are found the suffix is simply a single timestamp.
 
 ## Cached Services
 
@@ -48,7 +55,7 @@ Each service method is annotated with `@Cacheable` and `@RedisLock` to ensure th
 
 ## Cache Clean Up
 
-`CacheController` delegates cleanup to `CacheCleanUpService` through the `/cache/cleanUp` endpoint. Cache keys include update timestamps for the indicators used to compute the value. During cleanup the service compares these timestamps with the current ones and removes only the keys referencing outdated or deleted indicators so valid entries survive the purge.
+`CacheController` delegates cleanup to `CacheCleanUpService` through the `/cache/cleanUp` endpoint. Cache keys include update timestamps for the indicators used to compute the value. During cleanup the service compares these timestamps with the current ones and removes only the keys referencing outdated or deleted indicators so valid entries survive the purge. Keys whose version suffix still matches the latest timestamp are kept intact.
 
 ## Suggested Improvements
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,58 @@
+# Caching Overview
+
+This document describes how caching is implemented in the Insights API and lists the current cache entries. It also suggests possible improvements.
+
+## Cache Technology
+
+The application uses Spring's cache abstraction backed by Redis. Redis connection settings and cache properties are defined in `application.yml`. Caches have a default time‑to‑live of 24 hours:
+
+```yaml
+spring:
+  cache:
+    type: redis
+    cache-names: urban-core, thermal-spot, population, osm-quality, humanitarian-impact, functions, correlation-rate-all,
+      metrics-num-den, metrics-num-den-with-uuid, correlation-rate-polygon, correlation-rate-polygon-all,
+      metrics-num-not-empty-layers, advanced-analytics-all, advanced-analytics, covariance-rate-all, covariance-rate-polygon
+    redis:
+      time-to-live: 86400s
+```
+
+Feature flags under the `cache` section allow enabling or disabling cache usage for individual services.
+
+## Key Generation
+
+`CacheConfig` defines several `KeyGenerator` beans used by the `@Cacheable` annotations. They create stable hash-based keys for different combinations of parameters to avoid leaking sensitive values and to keep the keys short.
+
+Only parameters of known DTO types are scanned for indicator IDs when composing
+versioned cache keys. Strings or generic lists are ignored, so callers that need
+per-indicator caching must pass the IDs using `BivariateIndicatorDto`,
+`NumeratorsDenominatorsDto`, `FunctionArgs` or related DTOs.
+
+## Cached Services
+
+Caching is implemented through facade classes found in `service/cacheable/impl`. Each facade wraps a repository or transformer that performs the actual calculations. The following services use caching:
+
+- **UrbanCoreService** (`urban-core` cache)
+- **ThermalSpotStatisticService** (`thermal-spot` cache)
+- **PopulationService** (`population` cache)
+- **OsmQualityService** (`osm-quality` cache)
+- **HumanitarianImpactService** (`humanitarian-impact` cache)
+- **FunctionsService** (`functions` cache)
+- **CorrelationRateService** (`correlation-rate-*` caches)
+- **CovarianceRateService** (`covariance-rate-*` caches)
+- **MetricsService** (`metrics-*` caches)
+- **AdvancedAnalyticsService** (`advanced-analytics*` caches)
+
+Each service method is annotated with `@Cacheable` and `@RedisLock` to ensure that only one pod performs an expensive operation when the cache is cold. The `RedisLockAspect` implements a simple distributed lock using Redis keys prefixed with `lock::`.
+
+
+## Cache Clean Up
+
+`CacheController` delegates cleanup to `CacheCleanUpService` through the `/cache/cleanUp` endpoint. Cache keys include update timestamps for the indicators used to compute the value. During cleanup the service compares these timestamps with the current ones and removes only the keys referencing outdated or deleted indicators so valid entries survive the purge.
+
+## Suggested Improvements
+
+- **Metrics**: Monitor cache hit ratios per service to tune expiration times and key design.
+- **Granular invalidation**: Currently eviction clears entire caches. Investigate evicting by key when possible to reduce cache churn.
+- **Configuration**: Move cache TTL values to dedicated configuration properties so they can be adjusted without redeploying the application.
+- **Fallback**: Consider falling back to repository methods when Redis is unavailable instead of failing the request.

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -6,7 +6,7 @@ This document summarizes the available HTTP and GraphQL endpoints implemented in
 
 | Method | Path | Description | Source |
 |-------|------|-------------|-------|
-| GET | `/cache/cleanUp` | Clean all caches | `CacheController` |
+| GET | `/cache/cleanUp` | Remove outdated cache entries | `CacheController` |
 | POST | `/indicators/upload` | Create indicator by uploading CSV data and metadata. If an indicator with the same `param_id` already exists, a new version is created using its existing uuid. | `IndicatorController` |
 | PUT | `/indicators/upload` | Update indicator data | `IndicatorController` |
 | GET | `/indicators/upload/status/{uploadId}` | Get indicator upload status | `IndicatorController` |

--- a/src/main/java/io/kontur/insightsapi/configuration/CacheConfig.java
+++ b/src/main/java/io/kontur/insightsapi/configuration/CacheConfig.java
@@ -2,6 +2,12 @@ package io.kontur.insightsapi.configuration;
 
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import io.kontur.insightsapi.dto.BivariateIndicatorDto;
+import io.kontur.insightsapi.dto.BivariativeAxisDto;
+import io.kontur.insightsapi.dto.FunctionArgs;
+import io.kontur.insightsapi.dto.NumeratorsDenominatorsDto;
+import io.kontur.insightsapi.service.IndicatorService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.KeyGenerator;
@@ -10,19 +16,94 @@ import org.springframework.context.annotation.Configuration;
 
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
 
 @Configuration
 @EnableCaching
+@RequiredArgsConstructor
 public class CacheConfig extends CachingConfigurerSupport {
 
     private final HashFunction hashFunction = Hashing.murmur3_32_fixed();
+
+    private final IndicatorService indicatorService;
+
+    private String version() {
+        Instant lastUpdated = indicatorService.getIndicatorsLastUpdateDate();
+        return lastUpdated == null ? "none" : String.valueOf(lastUpdated.toEpochMilli());
+    }
+
+    /**
+     * Extract indicator identifiers from known DTO types. Strings are ignored
+     * because callers may pass geometry or other values that are not indicator IDs.
+     * If a method needs per-indicator caching it should supply the indicator ID
+     * wrapped in one of the supported DTOs.
+     */
+    private List<String> extractIds(Object param) {
+        List<String> ids = new ArrayList<>();
+        if (param == null) {
+            return ids;
+        }
+
+        if (param instanceof List<?> list) {
+            for (Object obj : list) {
+                ids.addAll(extractIds(obj));
+            }
+        } else if (param instanceof BivariateIndicatorDto dto) {
+            ids.add(dto.getId());
+        } else if (param instanceof FunctionArgs fArgs) {
+            ids.add(fArgs.getId());
+        } else if (param instanceof BivariativeAxisDto axis) {
+            if (axis.getNumerator_uuid() != null) {
+                ids.add(axis.getNumerator_uuid());
+            }
+            if (axis.getDenominator_uuid() != null) {
+                ids.add(axis.getDenominator_uuid());
+            }
+        } else if (param instanceof NumeratorsDenominatorsDto ndDto) {
+            if (ndDto.getXNumUuid() != null) {
+                ids.add(ndDto.getXNumUuid().toString());
+            }
+            if (ndDto.getXDenUuid() != null) {
+                ids.add(ndDto.getXDenUuid().toString());
+            }
+            if (ndDto.getYNumUuid() != null) {
+                ids.add(ndDto.getYNumUuid().toString());
+            }
+            if (ndDto.getYDenUuid() != null) {
+                ids.add(ndDto.getYDenUuid().toString());
+            }
+        }
+
+        return ids;
+    }
+
+    private String indicatorsVersion(Object... params) {
+        List<String> ids = new ArrayList<>();
+        for (Object param : params) {
+            ids.addAll(extractIds(param));
+        }
+        if (ids.isEmpty()) {
+            return version();
+        }
+        Map<String, Instant> updates = indicatorService.getIndicatorsLastUpdateDates(ids);
+        ids.sort(String::compareTo);
+        List<String> parts = new ArrayList<>();
+        for (String id : ids) {
+            Instant ts = updates.get(id);
+            parts.add(id + ":" + (ts == null ? "none" : ts.toEpochMilli()));
+        }
+        return String.join("-", parts);
+    }
 
     @Bean("stringKeyGenerator")
     public KeyGenerator customStringKeyGenerator() {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 1 && params[0] instanceof String) {
-                return hashFunction.hashString((String) params[0], StandardCharsets.UTF_8).toString();
+                return hashFunction.hashString((String) params[0], StandardCharsets.UTF_8)
+                        + "_" + indicatorsVersion(params[0]);
             }
             throw new IllegalArgumentException("Wrong params for StringKeyGenerator");
         };
@@ -33,7 +114,8 @@ public class CacheConfig extends CachingConfigurerSupport {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 2 && params[0] instanceof String && params[1] instanceof List) {
                 return hashFunction.hashString((String) params[0], StandardCharsets.UTF_8) + "_"
-                        + hashFunction.hashString(params[1].toString(), StandardCharsets.UTF_8);
+                        + hashFunction.hashString(params[1].toString(), StandardCharsets.UTF_8)
+                        + "_" + indicatorsVersion(params[0], params[1]);
             }
             throw new IllegalArgumentException("Wrong params for StringListKeyGenerator");
         };
@@ -44,7 +126,8 @@ public class CacheConfig extends CachingConfigurerSupport {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 2 && params[0] instanceof String && params[1] instanceof String) {
                 return hashFunction.hashString((String) params[0], StandardCharsets.UTF_8) + "_"
-                        + hashFunction.hashString((String) params[1], StandardCharsets.UTF_8);
+                        + hashFunction.hashString((String) params[1], StandardCharsets.UTF_8)
+                        + "_" + indicatorsVersion(params[0], params[1]);
             }
             throw new IllegalArgumentException("Wrong params for StringStringKeyGenerator");
         };
@@ -54,7 +137,8 @@ public class CacheConfig extends CachingConfigurerSupport {
     public KeyGenerator customListKeyGenerator() {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 1 && params[0] instanceof List) {
-                return hashFunction.hashString(params[0].toString(), StandardCharsets.UTF_8);
+                return hashFunction.hashString(params[0].toString(), StandardCharsets.UTF_8)
+                        + "_" + indicatorsVersion(params[0]);
             }
             throw new IllegalArgumentException("Wrong params for ListKeyGenerator");
         };
@@ -68,7 +152,8 @@ public class CacheConfig extends CachingConfigurerSupport {
                     && (params[2] instanceof String || params[2] instanceof List)) {
                 return hashFunction.hashString(params[0].toString(), StandardCharsets.UTF_8) + "_"
                         + hashFunction.hashString(params[1].toString(), StandardCharsets.UTF_8) + "_"
-                        + hashFunction.hashString(params[2].toString(), StandardCharsets.UTF_8);
+                        + hashFunction.hashString(params[2].toString(), StandardCharsets.UTF_8)
+                        + "_" + indicatorsVersion(params[0], params[1], params[2]);
             }
             throw new IllegalArgumentException("Wrong params for StringStringListKeyGenerator");
         };

--- a/src/main/java/io/kontur/insightsapi/configuration/CacheConfig.java
+++ b/src/main/java/io/kontur/insightsapi/configuration/CacheConfig.java
@@ -30,7 +30,13 @@ public class CacheConfig extends CachingConfigurerSupport {
 
     private final IndicatorService indicatorService;
 
-    private String version() {
+    /**
+     * Version string that changes whenever any indicator in the system is updated
+     * or removed. Stored as milliseconds since the epoch or {@code "none"} when
+     * there are no indicators. Used for caches that do not depend on particular
+     * indicator IDs.
+     */
+    private String globalVersion() {
         Instant lastUpdated = indicatorService.getIndicatorsLastUpdateDate();
         return lastUpdated == null ? "none" : String.valueOf(lastUpdated.toEpochMilli());
     }
@@ -41,7 +47,12 @@ public class CacheConfig extends CachingConfigurerSupport {
      * If a method needs per-indicator caching it should supply the indicator ID
      * wrapped in one of the supported DTOs.
      */
-    private List<String> extractIds(Object param) {
+    /**
+     * Collect all indicator identifiers found in the given parameter. The method
+     * recognizes a few DTO types that embed indicator IDs. Strings or lists of
+     * primitive values are ignored to avoid accidentally treating them as IDs.
+     */
+    private List<String> collectIndicatorIds(Object param) {
         List<String> ids = new ArrayList<>();
         if (param == null) {
             return ids;
@@ -49,7 +60,7 @@ public class CacheConfig extends CachingConfigurerSupport {
 
         if (param instanceof List<?> list) {
             for (Object obj : list) {
-                ids.addAll(extractIds(obj));
+                ids.addAll(collectIndicatorIds(obj));
             }
         } else if (param instanceof BivariateIndicatorDto dto) {
             ids.add(dto.getId());
@@ -80,13 +91,18 @@ public class CacheConfig extends CachingConfigurerSupport {
         return ids;
     }
 
-    private String indicatorsVersion(Object... params) {
+    /**
+     * Compose version string for a cache key based on indicator update times.
+     * When no indicator IDs are found among the parameters the {@link
+     * #globalVersion()} is used.
+     */
+    private String computeIndicatorsVersion(Object... params) {
         List<String> ids = new ArrayList<>();
         for (Object param : params) {
-            ids.addAll(extractIds(param));
+            ids.addAll(collectIndicatorIds(param));
         }
         if (ids.isEmpty()) {
-            return version();
+            return globalVersion();
         }
         Map<String, Instant> updates = indicatorService.getIndicatorsLastUpdateDates(ids);
         ids.sort(String::compareTo);
@@ -98,52 +114,72 @@ public class CacheConfig extends CachingConfigurerSupport {
         return String.join("-", parts);
     }
 
+    /**
+     * KeyGenerator for methods with a single String argument. The argument value
+     * is hashed and combined with the indicator version derived from that
+     * argument if it contains indicator references.
+     */
     @Bean("stringKeyGenerator")
     public KeyGenerator customStringKeyGenerator() {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 1 && params[0] instanceof String) {
                 return hashFunction.hashString((String) params[0], StandardCharsets.UTF_8)
-                        + "_" + indicatorsVersion(params[0]);
+                        + "_" + computeIndicatorsVersion(params[0]);
             }
             throw new IllegalArgumentException("Wrong params for StringKeyGenerator");
         };
     }
 
+    /**
+     * KeyGenerator for methods taking a String and a List. Each argument is
+     * hashed separately and combined with the version computed from both
+     * arguments.
+     */
     @Bean("stringListKeyGenerator")
     public KeyGenerator customStringListKeyGenerator() {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 2 && params[0] instanceof String && params[1] instanceof List) {
                 return hashFunction.hashString((String) params[0], StandardCharsets.UTF_8) + "_"
                         + hashFunction.hashString(params[1].toString(), StandardCharsets.UTF_8)
-                        + "_" + indicatorsVersion(params[0], params[1]);
+                        + "_" + computeIndicatorsVersion(params[0], params[1]);
             }
             throw new IllegalArgumentException("Wrong params for StringListKeyGenerator");
         };
     }
 
+    /**
+     * KeyGenerator for methods with two String parameters.
+     */
     @Bean("stringStringKeyGenerator")
     public KeyGenerator customStringStringKeyGenerator() {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 2 && params[0] instanceof String && params[1] instanceof String) {
                 return hashFunction.hashString((String) params[0], StandardCharsets.UTF_8) + "_"
                         + hashFunction.hashString((String) params[1], StandardCharsets.UTF_8)
-                        + "_" + indicatorsVersion(params[0], params[1]);
+                        + "_" + computeIndicatorsVersion(params[0], params[1]);
             }
             throw new IllegalArgumentException("Wrong params for StringStringKeyGenerator");
         };
     }
 
+    /**
+     * KeyGenerator for single List parameter.
+     */
     @Bean("listKeyGenerator")
     public KeyGenerator customListKeyGenerator() {
         return (Object target, Method method, Object... params) -> {
             if (params.length == 1 && params[0] instanceof List) {
                 return hashFunction.hashString(params[0].toString(), StandardCharsets.UTF_8)
-                        + "_" + indicatorsVersion(params[0]);
+                        + "_" + computeIndicatorsVersion(params[0]);
             }
             throw new IllegalArgumentException("Wrong params for ListKeyGenerator");
         };
     }
 
+    /**
+     * KeyGenerator for methods that accept three parameters which can be either
+     * String or List. This is mainly used by analytics services.
+     */
     @Bean("threeParametersAsStringOrListKeyGenerator")
     public KeyGenerator customThreeParametersAsStringOrListKeyGenerator() {
         return (Object target, Method method, Object... params) -> {
@@ -153,7 +189,7 @@ public class CacheConfig extends CachingConfigurerSupport {
                 return hashFunction.hashString(params[0].toString(), StandardCharsets.UTF_8) + "_"
                         + hashFunction.hashString(params[1].toString(), StandardCharsets.UTF_8) + "_"
                         + hashFunction.hashString(params[2].toString(), StandardCharsets.UTF_8)
-                        + "_" + indicatorsVersion(params[0], params[1], params[2]);
+                        + "_" + computeIndicatorsVersion(params[0], params[1], params[2]);
             }
             throw new IllegalArgumentException("Wrong params for StringStringListKeyGenerator");
         };

--- a/src/main/java/io/kontur/insightsapi/configuration/CacheConfig.java
+++ b/src/main/java/io/kontur/insightsapi/configuration/CacheConfig.java
@@ -42,15 +42,11 @@ public class CacheConfig extends CachingConfigurerSupport {
     }
 
     /**
-     * Extract indicator identifiers from known DTO types. Strings are ignored
-     * because callers may pass geometry or other values that are not indicator IDs.
-     * If a method needs per-indicator caching it should supply the indicator ID
-     * wrapped in one of the supported DTOs.
-     */
-    /**
-     * Collect all indicator identifiers found in the given parameter. The method
-     * recognizes a few DTO types that embed indicator IDs. Strings or lists of
-     * primitive values are ignored to avoid accidentally treating them as IDs.
+     * Collect all indicator identifiers found in the given parameter. Strings
+     * or generic lists are ignored because callers may pass geometry or other
+     * values that are not indicator IDs. To enable per-indicator caching the ID
+     * must be wrapped in one of the supported DTOs such as {@link
+     * BivariateIndicatorDto} or {@link FunctionArgs}.
      */
     private List<String> collectIndicatorIds(Object param) {
         List<String> ids = new ArrayList<>();
@@ -106,12 +102,18 @@ public class CacheConfig extends CachingConfigurerSupport {
         }
         Map<String, Instant> updates = indicatorService.getIndicatorsLastUpdateDates(ids);
         ids.sort(String::compareTo);
-        List<String> parts = new ArrayList<>();
-        for (String id : ids) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ids.size(); i++) {
+            String id = ids.get(i);
             Instant ts = updates.get(id);
-            parts.add(id + ":" + (ts == null ? "none" : ts.toEpochMilli()));
+            sb.append(id)
+                    .append(':')
+                    .append(ts == null ? "none" : ts.toEpochMilli());
+            if (i < ids.size() - 1) {
+                sb.append('-');
+            }
         }
-        return String.join("-", parts);
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/io/kontur/insightsapi/controller/CacheController.java
+++ b/src/main/java/io/kontur/insightsapi/controller/CacheController.java
@@ -1,6 +1,6 @@
 package io.kontur.insightsapi.controller;
 
-import io.kontur.insightsapi.service.cacheable.CacheEvictable;
+import io.kontur.insightsapi.service.cacheable.CacheCleanUpService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 
 @Tag(name = "Cache", description = "Cache API")
 @RestController
@@ -18,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CacheController {
 
-    private final List<CacheEvictable> cacheEvictables;
+    private final CacheCleanUpService cacheCleanUpService;
 
     @Operation(summary = "Clean all caches.",
             tags = {"Cache"},
@@ -30,6 +29,6 @@ public class CacheController {
                     @ApiResponse(responseCode = "500", description = "Internal error")})
     @GetMapping("/cleanUp")
     public void cleanCaches() {
-        cacheEvictables.forEach(CacheEvictable::evict);
+        cacheCleanUpService.cleanUpIfRequired();
     }
 }

--- a/src/main/java/io/kontur/insightsapi/controller/CacheController.java
+++ b/src/main/java/io/kontur/insightsapi/controller/CacheController.java
@@ -27,6 +27,10 @@ public class CacheController {
                             content = @Content(mediaType = "application/json")),
                     @ApiResponse(responseCode = "400", description = "Bad Request"),
                     @ApiResponse(responseCode = "500", description = "Internal error")})
+    /**
+     * Remove outdated cache entries. Keys that still match the latest indicator
+     * update time remain in Redis.
+     */
     @GetMapping("/cleanUp")
     public void cleanCaches() {
         cacheCleanUpService.cleanUpIfRequired();

--- a/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
@@ -30,6 +30,8 @@ import java.nio.file.Path;
 import java.sql.*;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -357,6 +359,24 @@ public class IndicatorRepository {
     public Instant getIndicatorsLastUpdateDate() {
         Timestamp lastUpdated = jdbcTemplate.queryForObject("SELECT MAX(last_updated) FROM bivariate_indicators_metadata", Timestamp.class);
         return lastUpdated != null ? lastUpdated.toInstant() : null;
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Instant> getIndicatorsLastUpdateDates(List<String> indicatorIds) {
+        if (indicatorIds == null || indicatorIds.isEmpty()) {
+            return Map.of();
+        }
+        String inSql = String.format("'%s'", String.join("','", indicatorIds));
+        String sql = String.format("SELECT param_id, last_updated FROM bivariate_indicators_metadata WHERE param_id in (%s)", inSql);
+        return jdbcTemplate.query(sql, rs -> {
+            Map<String, Instant> result = new HashMap<>();
+            while (rs.next()) {
+                String id = rs.getString("param_id");
+                Timestamp ts = rs.getTimestamp("last_updated");
+                result.put(id, ts != null ? ts.toInstant() : null);
+            }
+            return result;
+        });
     }
 
     private void initParams(PreparedStatement ps, BivariateIndicatorDto bivariateIndicatorDto) throws SQLException, JsonProcessingException {

--- a/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
+++ b/src/main/java/io/kontur/insightsapi/repository/IndicatorRepository.java
@@ -356,18 +356,29 @@ public class IndicatorRepository {
         }
     }
 
+    /**
+     * @return timestamp of the most recently updated indicator or {@code null}
+     * if there are no indicators yet.
+     */
     public Instant getIndicatorsLastUpdateDate() {
-        Timestamp lastUpdated = jdbcTemplate.queryForObject("SELECT MAX(last_updated) FROM bivariate_indicators_metadata", Timestamp.class);
+        Timestamp lastUpdated = jdbcTemplate.queryForObject(
+                "SELECT MAX(last_updated) FROM bivariate_indicators_metadata",
+                Timestamp.class);
         return lastUpdated != null ? lastUpdated.toInstant() : null;
     }
 
     @Transactional(readOnly = true)
+    /**
+     * Fetch update timestamps for the provided indicator IDs.
+     */
     public Map<String, Instant> getIndicatorsLastUpdateDates(List<String> indicatorIds) {
         if (indicatorIds == null || indicatorIds.isEmpty()) {
             return Map.of();
         }
         String inSql = String.format("'%s'", String.join("','", indicatorIds));
-        String sql = String.format("SELECT param_id, last_updated FROM bivariate_indicators_metadata WHERE param_id in (%s)", inSql);
+        String sql = String.format(
+                "SELECT param_id, last_updated FROM bivariate_indicators_metadata WHERE param_id in (%s)",
+                inSql);
         return jdbcTemplate.query(sql, rs -> {
             Map<String, Instant> result = new HashMap<>();
             while (rs.next()) {

--- a/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
+++ b/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
@@ -145,10 +145,17 @@ public class IndicatorService {
         }
     }
 
+    /**
+     * Timestamp of the most recently updated indicator. Used to invalidate
+     * caches that don't track individual indicators.
+     */
     public Instant getIndicatorsLastUpdateDate() {
         return indicatorRepository.getIndicatorsLastUpdateDate();
     }
 
+    /**
+     * Fetch update timestamps for the given indicator IDs.
+     */
     public Map<String, Instant> getIndicatorsLastUpdateDates(List<String> indicatorIds) {
         return indicatorRepository.getIndicatorsLastUpdateDates(indicatorIds);
     }

--- a/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
+++ b/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -146,6 +147,10 @@ public class IndicatorService {
 
     public Instant getIndicatorsLastUpdateDate() {
         return indicatorRepository.getIndicatorsLastUpdateDate();
+    }
+
+    public Map<String, Instant> getIndicatorsLastUpdateDates(List<String> indicatorIds) {
+        return indicatorRepository.getIndicatorsLastUpdateDates(indicatorIds);
     }
 
     public boolean invalidIndicatorExternalId(String externalId) {

--- a/src/main/java/io/kontur/insightsapi/service/cacheable/CacheCleanUpService.java
+++ b/src/main/java/io/kontur/insightsapi/service/cacheable/CacheCleanUpService.java
@@ -6,12 +6,20 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class CacheCleanUpService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CacheCleanUpService.class);
 
     private final IndicatorService indicatorService;
     private final RedisTemplate<String, Object> redisTemplate;
@@ -20,13 +28,31 @@ public class CacheCleanUpService {
     private volatile String lastCleanUpVersion;
 
     /**
-     * Evicts cached data only if any indicator was updated or removed
-     * since the previous cleanup.
+     * Parse version string appended to a cache key. It is either a single
+     * timestamp (no indicator IDs) or a dash-separated list of
+     * {@code id:timestamp} pairs.
+     */
+    private Map<String, String> parseVersionPairs(String version) {
+        Map<String, String> result = new HashMap<>();
+        for (String pair : version.split("-")) {
+            String[] kv = pair.split(":");
+            if (kv.length == 2) {
+                result.put(kv[0], kv[1]);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Evicts cached data only if any indicator was updated or removed since the
+     * previous cleanup. Keys that still match the current update timestamp are
+     * left intact.
      */
     public synchronized void cleanUpIfRequired() {
         Instant lastUpdated = indicatorService.getIndicatorsLastUpdateDate();
         String currentGlobal = lastUpdated == null ? "none" : String.valueOf(lastUpdated.toEpochMilli());
         if (currentGlobal.equals(lastCleanUpVersion)) {
+            logger.debug("Cache cleanup skipped: version {} already processed", currentGlobal);
             return;
         }
 
@@ -35,33 +61,27 @@ public class CacheCleanUpService {
             if (keys == null) {
                 continue;
             }
+
             for (String key : keys) {
                 String[] parts = key.split("_");
                 String version = parts[parts.length - 1];
+
                 if (version.contains(":")) {
-                    String[] pairs = version.split("-");
-                    Set<String> ids = new java.util.HashSet<>();
-                    for (String pair : pairs) {
-                        String id = pair.split(":")[0];
-                        ids.add(id);
-                    }
-                    var currentMap = indicatorService.getIndicatorsLastUpdateDates(new java.util.ArrayList<>(ids));
-                    boolean outdated = false;
-                    for (String pair : pairs) {
-                        String[] kv = pair.split(":");
-                        String id = kv[0];
-                        String ts = kv[1];
-                        Instant cur = currentMap.get(id);
+                    Map<String, String> stored = parseVersionPairs(version);
+                    Map<String, Instant> current = indicatorService.getIndicatorsLastUpdateDates(new ArrayList<>(stored.keySet()));
+
+                    boolean outdated = stored.entrySet().stream().anyMatch(e -> {
+                        Instant cur = current.get(e.getKey());
                         String curVal = cur == null ? "none" : String.valueOf(cur.toEpochMilli());
-                        if (!ts.equals(curVal)) {
-                            outdated = true;
-                            break;
-                        }
-                    }
+                        return !e.getValue().equals(curVal);
+                    });
+
                     if (outdated) {
+                        logger.debug("Removing outdated entry {}", key);
                         redisTemplate.delete(key);
                     }
                 } else if (!version.equals(currentGlobal)) {
+                    logger.debug("Removing outdated entry {}", key);
                     redisTemplate.delete(key);
                 }
             }

--- a/src/main/java/io/kontur/insightsapi/service/cacheable/CacheCleanUpService.java
+++ b/src/main/java/io/kontur/insightsapi/service/cacheable/CacheCleanUpService.java
@@ -1,0 +1,71 @@
+package io.kontur.insightsapi.service.cacheable;
+
+import io.kontur.insightsapi.service.IndicatorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CacheCleanUpService {
+
+    private final IndicatorService indicatorService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final CacheManager cacheManager;
+
+    private volatile String lastCleanUpVersion;
+
+    /**
+     * Evicts cached data only if any indicator was updated or removed
+     * since the previous cleanup.
+     */
+    public synchronized void cleanUpIfRequired() {
+        Instant lastUpdated = indicatorService.getIndicatorsLastUpdateDate();
+        String currentGlobal = lastUpdated == null ? "none" : String.valueOf(lastUpdated.toEpochMilli());
+        if (currentGlobal.equals(lastCleanUpVersion)) {
+            return;
+        }
+
+        for (String cacheName : cacheManager.getCacheNames()) {
+            Set<String> keys = redisTemplate.keys(cacheName + "*");
+            if (keys == null) {
+                continue;
+            }
+            for (String key : keys) {
+                String[] parts = key.split("_");
+                String version = parts[parts.length - 1];
+                if (version.contains(":")) {
+                    String[] pairs = version.split("-");
+                    Set<String> ids = new java.util.HashSet<>();
+                    for (String pair : pairs) {
+                        String id = pair.split(":")[0];
+                        ids.add(id);
+                    }
+                    var currentMap = indicatorService.getIndicatorsLastUpdateDates(new java.util.ArrayList<>(ids));
+                    boolean outdated = false;
+                    for (String pair : pairs) {
+                        String[] kv = pair.split(":");
+                        String id = kv[0];
+                        String ts = kv[1];
+                        Instant cur = currentMap.get(id);
+                        String curVal = cur == null ? "none" : String.valueOf(cur.toEpochMilli());
+                        if (!ts.equals(curVal)) {
+                            outdated = true;
+                            break;
+                        }
+                    }
+                    if (outdated) {
+                        redisTemplate.delete(key);
+                    }
+                } else if (!version.equals(currentGlobal)) {
+                    redisTemplate.delete(key);
+                }
+            }
+        }
+        lastCleanUpVersion = currentGlobal;
+    }
+}


### PR DESCRIPTION
## Summary
- compute cache key versions from individual indicator timestamps
- parse per-indicator versions when cleaning Redis cache
- document the refined clean-up mechanism
- don't treat every string argument as an indicator
- update caching docs

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870faf37ac083248aeca008bc5e9492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cache key generation to include indicator versioning, ensuring more precise cache invalidation when indicator data changes.
  * Introduced a service for cleaning up only outdated cache entries, enhancing cache management efficiency.

* **Documentation**
  * Added comprehensive documentation on caching, including implementation details, key generation, and cleanup strategies.
  * Updated API documentation to clarify that the cache cleanup endpoint now removes only outdated cache entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->