### PR TITLE
fix(indicator): DEV-INSIGHTS-API-15 handle missing upload status

### DIFF
--- a/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
+++ b/src/main/java/io/kontur/insightsapi/service/IndicatorService.java
@@ -127,21 +127,26 @@ public class IndicatorService {
     public ResponseEntity<String> getIndicatorUploadStatus(String uploadId) {
         String owner = authService.getCurrentUsername().orElseThrow();
         String result = indicatorRepository.getIndicatorIdByUploadId(owner, uploadId);
+        if (result == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("upload failed or uploadId invalid");
+        }
+
         String[] parts = result.split("/");
+        if (parts.length < 2 || parts[1] == null || parts[1].isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("upload failed or uploadId invalid");
+        }
         String externalId = parts[0];
         String indicatorState = parts[1];
         if (indicatorState.equals("COPY IN PROGRESS")) {
             return ResponseEntity.status(HttpStatus.ACCEPTED).body(indicatorState);
-        } else if (indicatorState == null) {
-            // indicator not found by upload_id
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("upload scheduled or failed or uploadId invalid");
-        } else {
-            // uploaded successfully. indicator state is now either:
-            // - NEW (ready for processing)
-            // - TMP CREATED (ready for copying to stat_h3_transposed)
-            // - READY (available on UI)
-            return ResponseEntity.ok().body(externalId);
         }
+        // uploaded successfully. indicator state is now either:
+        // - NEW (ready for processing)
+        // - TMP CREATED (ready for copying to stat_h3_transposed)
+        // - READY (available on UI)
+        return ResponseEntity.ok().body(externalId);
     }
 
     public Instant getIndicatorsLastUpdateDate() {

--- a/src/test/java/io/kontur/insightsapi/service/IndicatorServiceTest.java
+++ b/src/test/java/io/kontur/insightsapi/service/IndicatorServiceTest.java
@@ -1,0 +1,40 @@
+package io.kontur.insightsapi.service;
+
+import io.kontur.insightsapi.repository.IndicatorRepository;
+import io.kontur.insightsapi.service.auth.AuthService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IndicatorServiceTest {
+
+    @Mock
+    private IndicatorRepository indicatorRepository;
+
+    @Mock
+    private AuthService authService;
+
+    @Test
+    void getIndicatorUploadStatusReturnsNotFoundWhenResultIsNull() {
+        IndicatorService service = new IndicatorService(indicatorRepository, null, null, authService);
+        String uploadId = "upload-id";
+        when(authService.getCurrentUsername()).thenReturn(Optional.of("owner"));
+        when(indicatorRepository.getIndicatorIdByUploadId("owner", uploadId)).thenReturn(null);
+
+        ResponseEntity<String> response = service.getIndicatorUploadStatus(uploadId);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode(),
+                "Expected NOT_FOUND when indicator upload status is absent for uploadId=" + uploadId);
+        assertEquals("upload failed or uploadId invalid", response.getBody(),
+                "Unexpected response body for absent indicator upload status");
+    }
+}


### PR DESCRIPTION
## Summary
- handle null result when checking indicator upload status
- return `404 Not Found` when upload status is missing
- update unit test for missing upload status

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*
- `mvn -q test` *(fails: Non-resolvable parent POM: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:2.6.7)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d40c5608324be09a384d6e0286b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Indicator upload status endpoint now returns consistent HTTP responses: 404 for missing/invalid upload IDs or results (replacing previous 400), 202 when processing is in progress, and 200 with the external ID for all other valid states. Improves predictability for API consumers.

* Tests
  * Added unit tests to verify 404 behavior when the upload status is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->