### PR TITLE
fix: PROD-INSIGHTS-API-26 support external servlet container

### DIFF
--- a/src/main/java/io/kontur/insightsapi/InsightsApiApplication.java
+++ b/src/main/java/io/kontur/insightsapi/InsightsApiApplication.java
@@ -2,13 +2,23 @@ package io.kontur.insightsapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableAsync
 @EnableRetry
-public class InsightsApiApplication {
+public class InsightsApiApplication extends SpringBootServletInitializer {
+
+    /**
+     * Allow running the application inside an external servlet container.
+     */
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(InsightsApiApplication.class);
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(InsightsApiApplication.class, args);


### PR DESCRIPTION
## Summary
- allow running inside external servlet container by extending SpringBootServletInitializer

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*
- `mvn -q test` *(fails: Non-resolvable parent POM; could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68b888459d3c832481b164230e77ddce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enabled deployment to external servlet containers (WAR-style), expanding hosting options for enterprise app servers.
  - Maintains support for standalone execution with no changes to API behavior.
  - Improves compatibility with managed environments and simplifies infrastructure integration.
  - No user-facing functionality changes; this is a deployment enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->